### PR TITLE
feature: added use of seed routing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ strum_macros = "0.18.0"
 ulid = { version = "0.3.3", features = ["serde"] }
 # This commit points to Seed 0.7.0 with important fixes.
 # Replace with `seed = "0.8.0"` (or newer) once released.
-seed = { git = "https://github.com/seed-rs/seed", rev = "0a538f0" }
-
+seed = { git = "https://github.com/seed-rs/seed" }
+seed_routing = {git ="https://github.com/arn-the-long-beard/seed-routing",  branch="main" }
 [profile.release]
 lto = true
 opt-level = 'z'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,11 +340,11 @@ fn view_filters() -> Node<Msg> {
                 Route::Completed => Some("Completed"),
                 Route::NotFound => return None, // or `return None`
             };
-                Some(li![a![
-                    C![IF!(route == router().current_route() => "selected")],
-                    attrs! {At::Href => route.to_url()},
-                    title.unwrap(),
-                ],])
+                title.map(|title| {
+                li![a![C![IF!(route == router().current_route() => "selected")],
+                attrs! {At::Href => route.to_url()},
+                title,]]
+            })
 
         })
     ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ struct SelectedTodo {
     input_element: ElRef<web_sys::HtmlInputElement>,
 }
 
-#[derive(Copy, Debug, Clone, Eq, PartialEq, AsUrl, Root, EnumIter)]
+#[derive(Copy, Debug, Clone, Eq, PartialEq, ParseUrl, Root, EnumIter)]
 enum Route {
     Active,
     Completed,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,12 @@ add_router!();
 // ------ ------
 
 fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
+
     router()
         .init(url)
-        .set_handler(orders, move |subs::UrlRequested(requested_url, _)| {
-            router().confirm_navigation(requested_url)
-        });
+        .subscribe(orders.subscribe_with_handle(
+        |subs::UrlRequested(requested_url, _)| router().confirm_navigation(requested_url),
+    ));
 
     Model {
         todos: LocalStorage::get(STORAGE_KEY).unwrap_or_default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ fn view_todo_list(
         Route::All => true,
         Route::Active => not(todo.completed),
         Route::Completed => todo.completed,
-        Route::NotFound => true
+        Route::NotFound => panic!("Not todo list when page has not been found")
     });
     ul![C!["todo-list"],
         todos.map(|todo| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,17 +338,14 @@ fn view_filters() -> Node<Msg> {
                 Route::All => Some("All"),
                 Route::Active => Some("Active"),
                 Route::Completed => Some("Completed"),
-                Route::NotFound => None, // or `return None`
+                Route::NotFound => return None, // or `return None`
             };
-            if title.is_some() {
                 Some(li![a![
                     C![IF!(route == router().current_route() => "selected")],
                     attrs! {At::Href => route.to_url()},
                     title.unwrap(),
                 ],])
-            } else {
-                None
-            }
+
         })
     ]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
 // ------ ------
 
 fn view(model: &Model) -> Vec<Node<Msg>> {
-    if router().current_route() == router().default_route() {
+    if router().current_route().is_default() {
         vec![div![
             "page not found ",
             br![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@ use std::mem;
 
 use seed_routing::*;
 use serde::{Deserialize, Serialize};
-use strum_macros::EnumIter;
 use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
 use ulid::Ulid;
 
 const ENTER_KEY: &str = "Enter";
@@ -333,21 +333,23 @@ fn view_footer(todos: &BTreeMap<Ulid, Todo>) -> Node<Msg> {
 fn view_filters() -> Node<Msg> {
     ul![
         C!["filters"],
-        Route::iter()
-            .filter(|route| route != &Route::NotFound)
-            .map(|filter| {
-                let title = match filter {
-                    Route::All => "All",
-                    Route::Active => "Active",
-                    Route::Completed => "Completed",
-                    Route::NotFound => "",
-                };
-                li![a![
-                    C![IF!(filter == router().current_route() => "selected")],
-                    attrs! {At::Href => filter.to_url()},
-                    title,
-                ],]
-            })
+        Route::iter().filter_map(|route| {
+            let title = match route {
+                Route::All => Some("All"),
+                Route::Active => Some("Active"),
+                Route::Completed => Some("Completed"),
+                Route::NotFound => None, // or `return None`
+            };
+            if title.is_some() {
+                Some(li![a![
+                    C![IF!(route == router().current_route() => "selected")],
+                    attrs! {At::Href => route.to_url()},
+                    title.unwrap(),
+                ],])
+            } else {
+                None
+            }
+        })
     ]
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ fn view(model: &Model) -> Vec<Node<Msg>> {
         nodes![
             view_header(&model.new_todo_title),
             IF!(not(model.todos.is_empty()) => vec![
-                view_main(&model.todos, model.selected_todo.as_ref(), router().current_route()),
+                view_main(&model.todos, model.selected_todo.as_ref()),
                 view_footer(&model.todos),
             ])
         ]
@@ -230,12 +230,11 @@ fn view_header(new_todo_title: &str) -> Node<Msg> {
 fn view_main(
     todos: &BTreeMap<Ulid, Todo>,
     selected_todo: Option<&SelectedTodo>,
-    route: Route,
 ) -> Node<Msg> {
     section![
         C!["main"],
         view_toggle_all(todos),
-        view_todo_list(todos, selected_todo, route),
+        view_todo_list(todos, selected_todo),
     ]
 }
 
@@ -258,9 +257,8 @@ fn view_toggle_all(todos: &BTreeMap<Ulid, Todo>) -> Vec<Node<Msg>> {
 fn view_todo_list(
     todos: &BTreeMap<Ulid, Todo>,
     selected_todo: Option<&SelectedTodo>,
-    route: Route,
 ) -> Node<Msg> {
-    let todos = todos.values().filter(|todo| match route {
+    let todos = todos.values().filter(|todo| match router().current_route() {
         Route::All => true,
         Route::Active => not(todo.completed),
         Route::Completed => todo.completed,


### PR DESCRIPTION
Hey mate !


Current Todo list

- [x] Add better initialization for the router 
- [x] Update Routes to Route
- [x] Update how to use of confirm_navigation 
- [x] Make getters for current_route and default_route
- [x] Add a property to Route so we know if the route is default
- [x] update AsUrl to ToUrl or maybe ParseUrl?
- [x] update example to panic when not found in filfer
- [x] update example to use filter_map


As promised, here is a different version of the todo with the use of seed_routing,

Here are the interesting part regarding size of the package after `cargo make build_release` : 

- Original  : 

`wc -c pkg/package_bg.wasm`

> 361963 pkg/package_bg.wasm


- With seed_routing : 

` wc -c pkg/package_bg.wasm`

> 368220 pkg/package_bg.wasm

We got **6257** more with seed_routing.

Now, I did not try to optimize my library. We could use `feature gate` for compiling on what we need like AsUrl & Root , and other one for the full mode with `RoutingModule`.

Also, the todo MVC is a very simple example, so the benefit of my library are quite small here compare to bigger example where it saves so much code and complexity by using the same concept as in Angular/View/React. 

So, Should I try to add the Routing on the time tracker ?


