### PR TITLE
Add play-seed specfics

### DIFF
--- a/.play-seed/config.yml
+++ b/.play-seed/config.yml
@@ -1,0 +1,7 @@
+# This defines which directories would be loaded into playground from Github
+# default would be only "src" folder, but we need to configure to load css folder
+# as well
+directories: [
+  "src",
+  "css"
+]

--- a/.play-seed/main.html
+++ b/.play-seed/main.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="../css/base.css"/>
+  <link rel="stylesheet" href="../css/index.css"/>
+</head>
+<body>
+  <!-- Here Seed would mount rendered page -->
+  <div class="todoapp"></div>
+
+  <!-- Main script is needed for demo, real production code would be different -->
+  <script src="./main.js" type="module"></script>
+</body>
+</html>

--- a/.play-seed/main.js
+++ b/.play-seed/main.js
@@ -1,0 +1,11 @@
+// Following is some Play Seed specific boilerplate, 
+// you will not need it in production, it exists here only 
+// for demo purposes
+
+import init from '../out/index.js'
+
+fetch('../out/main.wasm')
+  .then(response => response.arrayBuffer())
+  .then(bytes => {
+    init(bytes)
+})


### PR DESCRIPTION
Due to some of sandbox limitations, using regular browser entrypoint (index.html) is not possible, so some configurations specific to playground had to be added to the repository. 
Check out how this works:
https://ide.play-seed.dev/?github=strowk/seed-app-todomvc