### PR TITLE
Consider title trim and empty case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,8 +202,13 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         }
         Msg::SaveSelectedTodo => {
             if let Some(selected_todo) = model.selected_todo.take() {
-                if let Some(todo) = model.todos.get_mut(&selected_todo.id) {
-                    todo.title = selected_todo.title;
+                let title = selected_todo.title.trim();
+                if title.is_empty() {
+                    model.todos.remove(&selected_todo.id);
+                } else {
+                    if let Some(todo) = model.todos.get_mut(&selected_todo.id) {
+                        todo.title = title.to_owned();
+                    }
                 }
             }
         }


### PR DESCRIPTION
`SaveSelectedTodo` now updates the editing title without condition. However, the spec of ToDo MVC says:

> Make sure to .trim() the input and then check that it's not empty. If it's empty the todo should instead be destroyed.

I added the logic of this spec.

I am new to Rust and it is my first week of learning Rust and Seed. So I am not sure if I am writing it correctly (I did not fully understand the borrow/move and lifetime things yet). Please feel free to correct it if there is a better way to do it!

And I wonder should I also submit the same change here: https://github.com/seed-rs/seed/blob/master/examples/todomvc/src/lib.rs